### PR TITLE
Change name of Enforcer Confrontation Gear to Enforcer Combat Gear

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -255,7 +255,7 @@ outfit "Large Steering Module"
 	"steering flare sound" "atomic small"
 	description "By focusing on small, modular engines rather than the massive capital ship drives that most other species develop, the Coalition loses some of the potential efficiency for very large ships, but gains a considerable amount of flexibility."
 
-outfit "Enforcer Confrontation Gear"
+outfit "Enforcer Combat Gear"
 	category "Hand to Hand"
 	licenses
 		Heliarch


### PR DESCRIPTION
NOTICE: Delete the sections that do not apply to your PR, and fill out the section that does.
(You can open a PR to add or improve a section, if you find them lacking!) 

## Summary
I changed the name of Enforcer Confrontation gear to Enforcer combat gear because enforcer combat gear is to long, and causes it to replace part of the word confrontation with dots (see below)

## UI Screenshots
![ascreenshotwhynot](https://user-images.githubusercontent.com/70719891/120721394-bcb6be80-c49b-11eb-956f-eb4b02565e47.jpg)
