### PR TITLE
Very minor wording change

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -26,7 +26,7 @@ mission "Liberate Kornephoros"
 		event "prepare for battle of Kornephoros"
 		conversation
 			`The mood in the spaceport is solemn. No one has had time yet to count up the losses, on both sides of the battle, but it is likely that over a thousand lives were lost. And because the Navy is held in such high regard even here where Parliament and the Paradise Planets are viewed with disgust, many of the militia captains are almost as saddened by the loss of Navy lives as by the loss of some of their own.`
-			`	You find Tomek walking among the fleet, conversing with a large group of captains and crew members and assessing the damage they have suffered. When he sees you he says, "Captain <last>! How is your <ship> holding together?"`
+			`	You find Tomek walking among the fleet, conversing with a large group of captains and crew members and assessing the damage they have suffered. When he sees you he says, "Captain <last>! How is the <ship> holding together?"`
 			choice
 				`	"She took a bit of a pounding, but I've patched her up."`
 				`	"Just fine. It'd take more than a few Cruisers to destroy the <ship>."`


### PR DESCRIPTION
## Summary
I was playing through the first two battles of the free worlds just for fun, and I noticed my flagship Deadhunter (osprey I capped from pirates) was referred to as "your deadhunter" not "the deadhunter" which didn't really make sense. If the game just said "your ship" or "your Osprey" that would make much more sense, but actually using the name of the flagship with "your" in front of it doesn't make sense. So I changed it.